### PR TITLE
Add adjustStartupTimeout() functionality

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -24,6 +24,7 @@ isAsleep	KEYWORD2
 setPowerProfile	KEYWORD2
 adjustATTimeout	KEYWORD2
 adjustSendReceiveTimeout	KEYWORD2
+adjustStartupTimeout	KEYWORD2
 useMSSTMWorkaround	KEYWORD2
 getSystemTime	KEYWORD2
 getFirmwareVersion	KEYWORD2

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=IridiumSBDi2c
-version=3.0.1
+version=3.0.2
 author=Mikal Hart and Paul Clark (PaulZC)
 maintainer=SparkFun Electronics <sparkfun.com>
 sentence=This library supports satellite data transmissions from anywhere on earth using the RockBLOCK family of Iridium 9602 and 9603 modems.

--- a/src/IridiumSBD.cpp
+++ b/src/IridiumSBD.cpp
@@ -168,6 +168,12 @@ void IridiumSBD::adjustSendReceiveTimeout(int seconds)
    this->sendReceiveTimeout = seconds;
 }
 
+// Tweak ISBD startup timeout
+void IridiumSBD::adjustStartupTimeout(int seconds)
+{
+   this->startupTimeout = seconds;
+}
+
 void IridiumSBD::useMSSTMWorkaround(bool useWorkAround) // true to use workaround from Iridium Alert 5/7
 {
    this->msstmWorkaroundRequested = useWorkAround;
@@ -539,7 +545,7 @@ int IridiumSBD::internalBegin()
          return ISBD_CANCELLED;
 
    // Turn on modem and wait for a response from "AT" command to begin
-   for (unsigned long start = millis(); !modemAlive && millis() - start < 1000UL * ISBD_STARTUP_MAX_TIME;)
+   for (unsigned long start = millis(); !modemAlive && millis() - start < 1000UL * this->startupTimeout;)
    {
       send(F("AT\r"));
       modemAlive = waitForATResponse();

--- a/src/IridiumSBD.h
+++ b/src/IridiumSBD.h
@@ -114,6 +114,7 @@ public:
    void setPowerProfile(POWERPROFILE profile); // 0 = direct connect (default), 1 = USB
    void adjustATTimeout(int seconds);          // default value = 20 seconds
    void adjustSendReceiveTimeout(int seconds); // default value = 300 seconds
+   void adjustStartupTimeout(int seconds); // default value = 240 seconds
    void useMSSTMWorkaround(bool useMSSTMWorkAround); // true to use workaround from Iridium Alert 5/7/13
    void enableRingAlerts(bool enable);
 
@@ -140,6 +141,7 @@ public:
       sbdixInterval = ISBD_USB_SBDIX_INTERVAL;
       atTimeout = ISBD_DEFAULT_AT_TIMEOUT;
       sendReceiveTimeout = ISBD_DEFAULT_SENDRECEIVE_TIME;
+      startupTimeout = ISBD_STARTUP_MAX_TIME;
       remainingMessages = -1;
       asleep = true;
       reentrant = false;
@@ -168,6 +170,7 @@ public:
       sbdixInterval = ISBD_USB_SBDIX_INTERVAL;
       atTimeout = ISBD_DEFAULT_AT_TIMEOUT;
       sendReceiveTimeout = ISBD_DEFAULT_SENDRECEIVE_TIME;
+      startupTimeout = ISBD_STARTUP_MAX_TIME;
       remainingMessages = -1;
       asleep = true;
       reentrant = false;
@@ -206,6 +209,7 @@ private:
    int sbdixInterval;
    int atTimeout;
    int sendReceiveTimeout;
+   int startupTimeout;
    unsigned long lastCheck = 0; // The time in millis when the I2C bus was last checked (limits I2C traffic)
    const uint8_t I2C_POLLING_WAIT_MS = 5; //Limit checking of new characters to every 5 ms (roughly 10 chars at 19200 baud)
 


### PR DESCRIPTION
Hi @PaulZC,

A small PR to add functionality to control the startup timeout of the Iridium modem. This is perhaps more relevant to users of the RockBLOCK, who are required to wait for the default duration of 240 seconds if their modem is not starting up properly. 

The startup timeout continues to default to the original period of 240 seconds as specified by:
```
#define ISBD_STARTUP_MAX_TIME           240
```
Similar to the other timeout functions, this value can now be modified using: `modem.adjustStartupTimeout(60);`

A quick test shows the timeout working as intended:
```
10:01:34.945 -> Starting modem...
10:02:35.541 -> Begin failed: error 5
10:02:35.541 -> No modem detected: check wiring.
```

Cheers,
Adam