### PR TITLE
Set SBD Session Timeout lower than AT timeout

### DIFF
--- a/src/IridiumSBD.cpp
+++ b/src/IridiumSBD.cpp
@@ -581,6 +581,13 @@ int IridiumSBD::internalBegin()
          return cancelled() ? ISBD_CANCELLED : ISBD_PROTOCOL_ERROR;
    }
 
+   // Set SBD Session Timeout slightly lower than AT timeout
+   send(F("AT+SBDST="), true, false);
+   send(atTimeout - 1);
+   send(F("\r"), false);
+   if (!waitForATResponse())
+      return cancelled() ? ISBD_CANCELLED : ISBD_PROTOCOL_ERROR;
+
    // Enable or disable RING alerts as requested by user
    // By default they are on if a RING pin was supplied on constructor
    diagprint(F("Ring alerts are")); diagprint(ringAlertsEnabled ? F("") : F(" NOT")); diagprint(F(" enabled.\r\n"));

--- a/src/IridiumSBD.h
+++ b/src/IridiumSBD.h
@@ -112,7 +112,7 @@ public:
 
    typedef enum { DEFAULT_POWER_PROFILE = 0, USB_POWER_PROFILE = 1 } POWERPROFILE;
    void setPowerProfile(POWERPROFILE profile); // 0 = direct connect (default), 1 = USB
-   void adjustATTimeout(int seconds);          // default value = 20 seconds
+   void adjustATTimeout(int seconds);          // default value = 30 seconds
    void adjustSendReceiveTimeout(int seconds); // default value = 300 seconds
    void adjustStartupTimeout(int seconds); // default value = 240 seconds
    void useMSSTMWorkaround(bool useMSSTMWorkAround); // true to use workaround from Iridium Alert 5/7/13


### PR DESCRIPTION
Set SBD Session Timeout slightly lower than AT timeout to prevent ISBD_PROTOCOL_ERROR when an SBDIX attempt takes longer than AT timeout.

This allows SBDIX to return 17 "Gateway not responding (local session timeout)" which reflects what actually happened, rather than letting the AT command time out and exiting the SBDIX retry loop.

Actually fixes sparkfun/SparkFun_IridiumSBD_I2C_Arduino_Library#6.

Fix incorrect comment for AT timeout default value.